### PR TITLE
Use EM::Hiredis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,4 @@
 source :rubygems
 gemspec
 
-# Our fork adds support for the reconnect callback (from librato/em-redis)
-gem "em-redis", "0.3.0", :git => "https://github.com/groupme/em-redis.git", :ref => "7627cae"
 gem "holt_winters", :git => "git://github.com/cmdrkeene/holt_winters.git"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ In a separate process, start up a worker:
       # do work with options
     end
 
+## Redis
+
+Pace connects to Redis with a URI that's looked up in the following order:
+
+ * Pace.redis_url attr_accessor
+ * REDIS_URL environment variable
+ * Defaults to 127.0.0.1:6379/0
+
 ## Throttling
 
 It's very easy to overwhelm a remote service with pace. You can specify

--- a/pace.gemspec
+++ b/pace.gemspec
@@ -18,10 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  # See Gemfile; using a Github fork
-  # s.add_dependency "em-redis", ">= 0.3.0"
-
   s.add_dependency "eventmachine", ">= 0.12.10"
+  s.add_dependency "em-hiredis", ">= 0.1.0"
   s.add_dependency "uuid"
   s.add_dependency "systemu" # macaddr 1.2.0 breaks this
   # s.add_dependency "gsl"

--- a/spec/pace/worker_spec.rb
+++ b/spec/pace/worker_spec.rb
@@ -374,5 +374,19 @@ describe Pace::Worker do
         worker.shutdown
       end
     end
+
+    it "does not start multiple fetch loops if resume is called multiple times when paused" do
+      Resque.enqueue(Work)
+
+      worker = Pace::Worker.new(Work.queue)
+      worker.start do |job|
+        worker.pause
+
+        EM.should_receive(:next_tick).once
+        worker.resume
+        worker.resume
+        EM.stop
+      end
+    end
   end
 end

--- a/spec/pace_spec.rb
+++ b/spec/pace_spec.rb
@@ -5,44 +5,15 @@ describe Pace do
     let(:connection) { double(EM::Connection) }
 
     it "returns a Redis connection" do
-      EM::Protocols::Redis.should_receive(:connect).with(
-        :host     => "127.0.0.1",
-        :port     => 6379,
-        :password => nil,
-        :db       => 0
-      ).and_return(connection)
-
+      EM::Hiredis.should_receive(:connect).with(nil).and_return(connection)
       Pace.redis_connect.should == connection
     end
 
-    it "uses any options (set either directly or via Pace.start)" do
-      Pace.redis_options = {:url => "redis://user:secret@some.host.local:9999/1"}
-
-      EM::Protocols::Redis.should_receive(:connect).with(
-        :host     => "some.host.local",
-        :port     => 9999,
-        :password => "secret",
-        :db       => 1
-      ).and_return(connection)
-
+    it "uses Pace.redis_url if set" do
+      Pace.redis_url = "redis://user:secret@some.host.local:9999/1"
+      EM::Hiredis.should_receive(:connect).with(Pace.redis_url).and_return(connection)
       Pace.redis_connect.should == connection
-      Pace.redis_options = nil
-    end
-
-    it "can be set using the PACE_REDIS environment variable" do
-      original_redis = ENV["PACE_REDIS"]
-      ENV["PACE_REDIS"] = "redis://user:secret@some.host.local:9999/1"
-
-      EM::Protocols::Redis.should_receive(:connect).with(
-        :host     => "some.host.local",
-        :port     => 9999,
-        :password => "secret",
-        :db       => 1
-      ).and_return(connection)
-
-      Pace.redis_connect.should == connection
-
-      ENV["PACE_REDIS"] = original_redis
+      Pace.redis_url = nil
     end
   end
 end


### PR DESCRIPTION
- PACE_REDIS is no longer supported; use REDIS_URL
- Pause/resume logic is re-implemented in Pace with control flags
  around the fetch loop. EM::Hiredis does not expose the connection,
  and I didn't feel like forking it just yet.
