### PR TITLE
Tag log lines with [pace] and start the fetch loop more reliably

### DIFF
--- a/bench/pace_http.rb
+++ b/bench/pace_http.rb
@@ -16,7 +16,7 @@
 require "pace"
 
 Pace.logger = Logger.new(File.join(File.dirname(__FILE__), "pace_http.log"))
-Pace.log("Starting #{'%0.6f' % Time.now}")
+Pace.logger.info("Starting #{'%0.6f' % Time.now}")
 
 Pace::Worker.new.start do |job|
   start_time = Time.now
@@ -29,6 +29,6 @@ Pace::Worker.new.start do |job|
     :request => "/?#{args}"
   )
   http.callback do |r|
-    Pace.log("http://localhost:9000/?#{args}", start_time)
+    Pace.logger.info("http://localhost:9000/?#{args}")
   end
 end

--- a/examples/defer.rb
+++ b/examples/defer.rb
@@ -11,7 +11,7 @@ worker.start do |job|
     rand(10).times { sleep 0.1 }
   }
   callback = proc { |result|
-    Pace.log(job.inspect, start_time)
+    Pace.logger.info(job.inspect)
   }
 
   EM.defer operation, callback

--- a/examples/echo.rb
+++ b/examples/echo.rb
@@ -2,5 +2,5 @@ require "pace"
 
 worker = Pace::Worker.new(ENV["PACE_QUEUE"] || "normal")
 worker.start do |job|
-  Pace.log(job.inspect, Time.now)
+  Pace.logger.info(job.inspect)
 end

--- a/examples/redis_test.rb
+++ b/examples/redis_test.rb
@@ -6,5 +6,5 @@ worker.start do |job|
     worker.instance_eval { @redis.close_connection }
   end
 
-  Pace.log(job.inspect, Time.now)
+  Pace.logger.info(job.inspect)
 end

--- a/lib/pace.rb
+++ b/lib/pace.rb
@@ -18,14 +18,6 @@ module Pace
     attr_accessor :namespace
     attr_accessor :redis_url
 
-    def log(message, start_time = nil)
-      if start_time
-        logger.info("%s (%0.6fs)" % [message, Time.now - start_time])
-      else
-        logger.info("%s" % message)
-      end
-    end
-
     def redis_connect
       EM::Hiredis.logger = Pace.logger
       EM::Hiredis.connect(redis_url)
@@ -35,6 +27,10 @@ module Pace
       @logger ||= begin
         logger = Logger.new(STDOUT)
         logger.level = Logger::INFO
+        logger.progname = "pace"
+        logger.formatter = Proc.new { |severity, datetime, progname, msg|
+          "[#{progname}] #{String === msg ? msg : msg.inspect}\n"
+        }
         logger
       end
     end


### PR DESCRIPTION
This was prompted by the recent failure of Pace to restart the fetch loop. I'm still not exactly sure why that happened, but I suspect Redis. In order to sort out the issue more easily next time, I'm doping all the log lines with the "[pace]" tag so they stand out a little more clearly.

Also, this patch attempts to make the initial loop setup more reliable by attaching it to a callback on the EM::Hiredis client.
